### PR TITLE
Add note about log4shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build products
 target/
+bin
 
 # IntelliJ data
 *.iml

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ to thank the Confluent team for their efforts in developing the
 connector and aim to continue keeping this fork well-maintained and
 truly open.
 
-# Documentation
+## Documentation
 
 The Source connector documentation can be found
 [here](docs/source-connector.md).
@@ -19,14 +19,18 @@ The Source connector documentation can be found
 The Sink connector documentation can be found
 [here](docs/sink-connector.md).
 
-# Contribute
+## Contribute
 
 [Source Code](https://github.com/aiven/jdbc-connector-for-apache-kafka)
 
 [Issue Tracker](https://github.com/aiven/jdbc-connector-for-apache-kafka/issues)
 
-# License
+## License
 
 The project is licensed under the
 [Apache 2 license](https://www.apache.org/licenses/LICENSE-2.0). See
 [LICENSE](LICENSE).
+
+## Security
+
+Security policies can be found [here](SECURITY.md) and the list of known vulnerabilities [here](cve-list.md)

--- a/cve-list.md
+++ b/cve-list.md
@@ -1,0 +1,11 @@
+# Known Vulnerabilities
+
+This page contains a list of all known vulnerabilities fixed in released versions of `JDBC connector for Apache Kafka`.
+
+## CVE-2021-45046 and CVE-2021-44228 a.k.a. Log4Shell
+
+The [CVE-2021-45046](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046) and [CVE-2021-44228](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228) vulnerabilities affect the `Apache Log4j` logging library in versions prior 2.15.0.
+
+`JDBC connector for Apache Kafka` does not use any version of [`Log4j`](https://logging.apache.org/log4j/2.x/) directly as it uses [`slf4j`](http://www.slf4j.org/log4shell.html), which acts as an abstraction layer over logging frameworks. For this reason, **this project is not directly impacted by said vulnerabilities**.
+
+We recommend all users of `JDBC connector for Apache Kafka` to inspect their dependency tree and make sure they are not including any impacted version of `Log4j`. In case `Log4J` is used, we highly encourage to update to a newer version where these vulnerabilities are addressed (`2.16.0` or newer at the time of this writing).


### PR DESCRIPTION
Add note about the no affectation of the Log4Shell reported vulnerabilities.

As I was modifiying the README file I fixed the headers. Also added a missing folder to `.gitignore`.