### PR TITLE
Support multi-row inserts

### DIFF
--- a/docs/sink-connector-config-options.rst
+++ b/docs/sink-connector-config-options.rst
@@ -58,6 +58,10 @@ Writes
 
       Use standard SQL ``INSERT`` statements.
 
+  ``multi``
+
+      Use multi-row inserts, e.g. ``INSERT INTO table_name (column_list) VALUES (value_list_1), (value_list_2), ... (value_list_n);``
+
   ``upsert``
 
       Use the appropriate upsert semantics for the target database if it is supported by the connector, e.g. ``INSERT .. ON CONFLICT .. DO UPDATE SET ..``.
@@ -68,7 +72,7 @@ Writes
 
   * Type: string
   * Default: insert
-  * Valid Values: [insert, upsert, update]
+  * Valid Values: [insert, multi, upsert, update]
   * Importance: high
 
 ``batch.size``

--- a/docs/sink-connector.md
+++ b/docs/sink-connector.md
@@ -77,6 +77,14 @@ from Kafka.
 This mode is used by default. To enable it explicitly, set
 `insert.mode=insert`.
 
+### Multi Mode
+
+In this mode, the connector executes an `INSERT` SQL query with multiple
+values (effectively inserting multiple row/records per query). 
+Supported in `SqliteDatabaseDialect` and `PostgreSqlDatabaseDialect`.
+
+To use this mode, set `insert.mode=multi`
+
 ### Update Mode
 
 In this mode, the connector executes `UPDATE` SQL query on each record

--- a/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/DatabaseDialect.java
@@ -325,6 +325,24 @@ public interface DatabaseDialect extends ConnectionProvider {
     );
 
     /**
+     * Build an INSERT statement for multiple rows.
+     *
+     * @param table            the identifier of the table; may not be null
+     * @param records          number of rows which will be inserted; must be a positive number
+     * @param keyColumns       the identifiers of the columns in the primary/unique key; may not be null
+     *                         but may be empty
+     * @param nonKeyColumns    the identifiers of the other columns in the table; may not be null but may
+     *                         be empty
+     * @return the INSERT statement; may not be null
+     */
+    String buildMultiInsertStatement(
+        TableId table,
+        int records,
+        Collection<ColumnId> keyColumns,
+        Collection<ColumnId> nonKeyColumns
+    );
+
+    /**
      * Build the INSERT prepared statement expression for the given table and its columns.
      *
      * @param table            the identifier of the table; may not be null
@@ -494,7 +512,18 @@ public interface DatabaseDialect extends ConnectionProvider {
          * @param record the sink record with values to be bound into the statement; never null
          * @throws SQLException if there is a problem binding values into the statement
          */
-        void bindRecord(SinkRecord record) throws SQLException;
+        default void bindRecord(SinkRecord record) throws SQLException {
+            bindRecord(1, record);
+        }
+
+        /**
+         * Bind the values in the supplied record, starting at the specified index.
+         *
+         * @param index     the index at which binding starts; must be positive
+         * @param record    the sink record with values to be bound into the statement; never null
+         * @throws SQLException if there is a problem binding values into the statement
+         */
+        int bindRecord(int index, SinkRecord record) throws SQLException;
     }
 
     /**

--- a/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/sink/JdbcSinkConfig.java
@@ -39,6 +39,7 @@ public class JdbcSinkConfig extends JdbcConfig {
 
     public enum InsertMode {
         INSERT,
+        MULTI,
         UPSERT,
         UPDATE;
     }
@@ -122,6 +123,8 @@ public class JdbcSinkConfig extends JdbcConfig {
         "The insertion mode to use. Supported modes are:\n"
             + "``insert``\n"
             + "    Use standard SQL ``INSERT`` statements.\n"
+            + "``multi``\n"
+            + "    Use multi-row ``INSERT`` statements.\n"
             + "``upsert``\n"
             + "    Use the appropriate upsert semantics for the target database if it is supported by "
             + "the connector, e.g. ``INSERT .. ON CONFLICT .. DO UPDATE SET ..``.\n"

--- a/src/main/java/io/aiven/connect/jdbc/util/CollectionUtils.java
+++ b/src/main/java/io/aiven/connect/jdbc/util/CollectionUtils.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.connect.jdbc.util;
+
+import java.util.Collection;
+
+public final class CollectionUtils {
+    private CollectionUtils() {
+    }
+
+    public static <T> boolean isEmpty(final Collection<T> collection) {
+        return collection == null || collection.isEmpty();
+    }
+}

--- a/src/test/java/io/aiven/connect/jdbc/sink/BufferedRecordsTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/sink/BufferedRecordsTest.java
@@ -21,10 +21,10 @@ import java.io.IOException;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
@@ -39,16 +39,22 @@ import io.aiven.connect.jdbc.util.TableId;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
 
+import static java.sql.Statement.SUCCESS_NO_INFO;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class BufferedRecordsTest {
 
     private final SqliteHelper sqliteHelper = new SqliteHelper(getClass().getSimpleName());
+    private final String dbUrl = sqliteHelper.sqliteUri();
 
     @Before
     public void setUp() throws IOException, SQLException {
@@ -63,34 +69,33 @@ public class BufferedRecordsTest {
     @Test
     public void correctBatching() throws SQLException {
         final HashMap<Object, Object> props = new HashMap<>();
-        props.put("connection.url", sqliteHelper.sqliteUri());
+        props.put("connection.url", dbUrl);
         props.put("auto.create", true);
         props.put("auto.evolve", true);
         props.put("batch.size", 1000); // sufficiently high to not cause flushes due to buffer being full
         final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
-        final String url = sqliteHelper.sqliteUri();
-        final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+        final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(dbUrl, config);
         final DbStructure dbStructure = new DbStructure(dbDialect);
 
         final TableId tableId = new TableId(null, null, "dummy");
         final BufferedRecords buffer = new BufferedRecords(
-            config, tableId, dbDialect, dbStructure, sqliteHelper.connection);
+                config, tableId, dbDialect, dbStructure, sqliteHelper.connection);
 
         final Schema schemaA = SchemaBuilder.struct()
-            .field("name", Schema.STRING_SCHEMA)
-            .build();
+                .field("name", Schema.STRING_SCHEMA)
+                .build();
         final Struct valueA = new Struct(schemaA)
-            .put("name", "cuba");
-        final SinkRecord recordA = new SinkRecord("dummy", 0, null, null, schemaA, valueA, 0);
+                .put("name", "cuba");
+        final SinkRecord recordA = wrapInSinkRecord(valueA);
 
         final Schema schemaB = SchemaBuilder.struct()
-            .field("name", Schema.STRING_SCHEMA)
-            .field("age", Schema.OPTIONAL_INT32_SCHEMA)
-            .build();
+                .field("name", Schema.STRING_SCHEMA)
+                .field("age", Schema.OPTIONAL_INT32_SCHEMA)
+                .build();
         final Struct valueB = new Struct(schemaB)
-            .put("name", "cuba")
-            .put("age", 4);
+                .put("name", "cuba")
+                .put("age", 4);
         final SinkRecord recordB = new SinkRecord("dummy", 1, null, null, schemaB, valueB, 1);
 
         // test records are batched correctly based on schema equality as records are added
@@ -116,43 +121,39 @@ public class BufferedRecordsTest {
         props.put("batch.size", 1000);
         final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
-        final String url = sqliteHelper.sqliteUri();
-        final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+        final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(dbUrl, config);
 
-        final int[] batchResponse = new int[2];
-        batchResponse[0] = Statement.SUCCESS_NO_INFO;
-        batchResponse[1] = Statement.SUCCESS_NO_INFO;
+        final int[] batchResponse = new int[] {SUCCESS_NO_INFO, SUCCESS_NO_INFO};
 
         final DbStructure dbStructureMock = mock(DbStructure.class);
-        when(dbStructureMock.createOrAmendIfNecessary(Matchers.any(JdbcSinkConfig.class),
-            Matchers.any(Connection.class),
-            Matchers.any(TableId.class),
-            Matchers.any(FieldsMetadata.class)))
-            .thenReturn(true);
+        when(dbStructureMock.createOrAmendIfNecessary(any(JdbcSinkConfig.class),
+                any(Connection.class),
+                any(TableId.class),
+                any(FieldsMetadata.class)))
+                .thenReturn(true);
 
         final PreparedStatement preparedStatementMock = mock(PreparedStatement.class);
         when(preparedStatementMock.executeBatch()).thenReturn(batchResponse);
 
         final Connection connectionMock = mock(Connection.class);
-        when(connectionMock.prepareStatement(Matchers.anyString())).thenReturn(preparedStatementMock);
+        when(connectionMock.prepareStatement(anyString())).thenReturn(preparedStatementMock);
 
         final TableId tableId = new TableId(null, null, "dummy");
         final BufferedRecords buffer = new BufferedRecords(config, tableId, dbDialect,
-            dbStructureMock, connectionMock);
+                dbStructureMock, connectionMock);
 
         final Schema schemaA = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA).build();
         final Struct valueA = new Struct(schemaA).put("name", "cuba");
-        final SinkRecord recordA = new SinkRecord("dummy", 0, null, null, schemaA, valueA, 0);
+        final SinkRecord recordA = wrapInSinkRecord(valueA);
         buffer.add(recordA);
 
         final Schema schemaB = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA).build();
         final Struct valueB = new Struct(schemaA).put("name", "cubb");
-        final SinkRecord recordB = new SinkRecord("dummy", 0, null, null, schemaB, valueB, 0);
+        final SinkRecord recordB = wrapInSinkRecord(valueB);
         buffer.add(recordB);
         buffer.flush();
 
     }
-
 
     @Test
     public void testInsertModeUpdate() throws SQLException {
@@ -164,27 +165,131 @@ public class BufferedRecordsTest {
         props.put("insert.mode", "update");
         final JdbcSinkConfig config = new JdbcSinkConfig(props);
 
-        final String url = sqliteHelper.sqliteUri();
-        final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(url, config);
+        final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(dbUrl, config);
         final DbStructure dbStructureMock = mock(DbStructure.class);
-        when(dbStructureMock.createOrAmendIfNecessary(Matchers.any(JdbcSinkConfig.class),
-            Matchers.any(Connection.class),
-            Matchers.any(TableId.class),
-            Matchers.any(FieldsMetadata.class)))
-            .thenReturn(true);
+        when(dbStructureMock.createOrAmendIfNecessary(any(JdbcSinkConfig.class),
+                any(Connection.class),
+                any(TableId.class),
+                any(FieldsMetadata.class)))
+                .thenReturn(true);
 
         final Connection connectionMock = mock(Connection.class);
+        final PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(connectionMock.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeBatch()).thenReturn(new int[1]);
+
         final TableId tableId = new TableId(null, null, "dummy");
         final BufferedRecords buffer = new BufferedRecords(config, tableId, dbDialect, dbStructureMock,
-            connectionMock);
+                connectionMock);
 
         final Schema schemaA = SchemaBuilder.struct().field("name", Schema.STRING_SCHEMA).build();
         final Struct valueA = new Struct(schemaA).put("name", "cuba");
-        final SinkRecord recordA = new SinkRecord("dummy", 0, null, null, schemaA, valueA, 0);
+        final SinkRecord recordA = wrapInSinkRecord(valueA);
         buffer.add(recordA);
+        buffer.flush();
 
-        Mockito.verify(connectionMock, Mockito.times(1))
-            .prepareStatement(Matchers.eq("UPDATE \"dummy\" SET \"name\" = ?"));
+        verify(connectionMock).prepareStatement(eq("UPDATE \"dummy\" SET \"name\" = ?"));
 
+    }
+
+    @Test
+    public void testInsertModeMultiAutomaticFlush() throws SQLException {
+        final JdbcSinkConfig config = multiModeConfig(2);
+
+        final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(dbUrl, config);
+        final DbStructure dbStructureMock = mock(DbStructure.class);
+        when(dbStructureMock.createOrAmendIfNecessary(any(JdbcSinkConfig.class),
+                any(Connection.class),
+                any(TableId.class),
+                any(FieldsMetadata.class)))
+                .thenReturn(true);
+
+        final Connection connection = mock(Connection.class);
+        final PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeBatch()).thenReturn(new int[]{2});
+
+        final TableId tableId = new TableId(null, null, "planets");
+        final BufferedRecords buffer = new BufferedRecords(config, tableId, dbDialect, dbStructureMock,
+                connection);
+
+        final Schema schema = newPlanetSchema();
+        for (int i = 1; i <= 5; i++) {
+            buffer.add(wrapInSinkRecord(newPlanet(schema, 1, "planet name " + i)));
+        }
+
+        final ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        // Given the 5 records, and batch size of 2, we expect 2 inserts.
+        // One record is still waiting in the buffer, and that is expected.
+        verify(connection, times(2)).prepareStatement(sqlCaptor.capture());
+        assertEquals(
+                sqlCaptor.getAllValues().get(0),
+                "INSERT INTO \"planets\"(\"name\",\"planetid\") VALUES (?,?),(?,?)"
+        );
+        assertEquals(
+                sqlCaptor.getAllValues().get(1),
+                "INSERT INTO \"planets\"(\"name\",\"planetid\") VALUES (?,?),(?,?)"
+        );
+    }
+
+    @Test
+    public void testInsertModeMultiExplicitFlush() throws SQLException {
+        final JdbcSinkConfig config = multiModeConfig(100);
+
+        final DatabaseDialect dbDialect = DatabaseDialects.findBestFor(dbUrl, config);
+        final DbStructure dbStructureMock = mock(DbStructure.class);
+        when(dbStructureMock.createOrAmendIfNecessary(any(JdbcSinkConfig.class),
+                any(Connection.class),
+                any(TableId.class),
+                any(FieldsMetadata.class)))
+                .thenReturn(true);
+
+        final Connection connection = mock(Connection.class);
+        final PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeBatch()).thenReturn(new int[]{2});
+
+        final TableId tableId = new TableId(null, null, "planets");
+        final BufferedRecords buffer = new BufferedRecords(config, tableId, dbDialect, dbStructureMock,
+                connection);
+
+        final Schema schema = newPlanetSchema();
+        final Struct valueA = newPlanet(schema, 1, "mercury");
+        final Struct valueB = newPlanet(schema, 2, "venus");
+        buffer.add(wrapInSinkRecord(valueA));
+        buffer.add(wrapInSinkRecord(valueB));
+        buffer.flush();
+
+        verify(connection).prepareStatement(
+                "INSERT INTO \"planets\"(\"name\",\"planetid\") VALUES (?,?),(?,?)"
+        );
+
+    }
+
+    private Struct newPlanet(final Schema schema, final int id, final String name) {
+        return new Struct(schema)
+                .put("planetid", id)
+                .put("name", name);
+    }
+
+    private Schema newPlanetSchema() {
+        return SchemaBuilder.struct()
+                .field("name", Schema.STRING_SCHEMA)
+                .field("planetid", Schema.INT32_SCHEMA)
+                .build();
+    }
+
+    private JdbcSinkConfig multiModeConfig(final int batchSize) {
+        return new JdbcSinkConfig(Map.of(
+                "connection.url", "",
+                "auto.create", true,
+                "auto.evolve", true,
+                "batch.size", batchSize,
+                "insert.mode", "multi"
+        ));
+    }
+
+    private SinkRecord wrapInSinkRecord(final Struct value) {
+        return new SinkRecord("dummy-topic", 0, null, null, value.schema(), value, 0);
     }
 }


### PR DESCRIPTION
Hello, Aiven team!

This is in relation to #40 (and, originally #34). It takes the spike in #39 from @ahmeroxa as a basis.

Multi-row insert is implemented in a separate dialect and added to only Pg and SQLite. I wasn't comfortable adding multi-row support to GenericDatabaseDialect, since I wasn't able to actually confirm that all databases support it. I found that for example, PostgreSQL didn't support this until 8.2 But if we can, for example, assume that it's only the minority of DBs (and versions) which do not support it, then that could be a reason for putting multi-row inserts into GenericDatabaseDialect.

Best wishes,

Haris

**Update**: Since it looks like the most used DBs (MySQL, Pg, SQL Server) all support multi-row inserts, the default for the dialects is to support multi-row inserts.