### PR TITLE
Bump jdbc postgressql dependency to 42.2.25 because of CVE-2022-21724

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     compileOnly "org.apache.kafka:connect-api:$kafkaVersion"
 
     runtimeOnly "org.xerial:sqlite-jdbc:3.32.3"
-    runtimeOnly "org.postgresql:postgresql:42.2.10"
+    runtimeOnly "org.postgresql:postgresql:42.2.25"
     runtimeOnly "net.sourceforge.jtds:jtds:1.3.1"
     runtimeOnly "net.snowflake:snowflake-jdbc:3.12.8"
     runtimeOnly "com.microsoft.sqlserver:mssql-jdbc:8.2.1.jre11"


### PR DESCRIPTION
Bump dependency because of CVE-2022-21724 in postgres jdbc
Impact analysis from pgjdbc team https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-v7wg-cpwc-24m4