### PR TITLE
Fix regression with partitioned tables in PostgreSQL

### DIFF
--- a/src/main/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -496,12 +496,15 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         final Connection connection,
         final TableId tableId
     ) throws SQLException {
+        final DatabaseMetaData metadata = connection.getMetaData();
+        final String[] tableTypes = tableTypes(metadata, new HashSet<>(Arrays.asList("TABLE", "PARTITIONED TABLE")));
+
         log.info("Checking {} dialect for existence of table {}", this, tableId);
         try (final ResultSet rs = connection.getMetaData().getTables(
             tableId.catalogName(),
             tableId.schemaName(),
             tableId.tableName(),
-            new String[]{"TABLE"}
+            tableTypes
         )) {
             final boolean exists = rs.next();
             log.info("Using {} dialect table {} {}", this, tableId, exists ? "present" : "absent");

--- a/src/main/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
+++ b/src/main/java/io/aiven/connect/jdbc/dialect/PostgreSqlDatabaseDialect.java
@@ -65,6 +65,8 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
             Schema.Type.STRING, String.class
     );
 
+    private static final List<String> SINK_TABLE_TYPE_DEFAULT = List.of("TABLE", "PARTITIONED TABLE");
+
     /**
      * The provider for {@link PostgreSqlDatabaseDialect}.
      */
@@ -414,4 +416,8 @@ public class PostgreSqlDatabaseDialect extends GenericDatabaseDialect {
         return "";
     }
 
+    @Override
+    protected List<String> getDefaultSinkTableTypes() {
+        return SINK_TABLE_TYPE_DEFAULT;
+    }
 }


### PR DESCRIPTION
Add handling for detecting existence of partitioned tables explicitly.

PostgreSQL JDBC Driver update from 42.2.10 to 42.2.25 in #113 caused
partitioned tables to broke due upstream change of separating types of
normal table and partitioned table as explained in
https://github.com/pgjdbc/pgjdbc/pull/1708