### PR TITLE
Improve integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,6 @@ ext {
 sourceSets {
     integrationTest {
         java.srcDir file('src/integrationTest/java')
-        resources.srcDir file('src/integrationTest/resources')
         compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
         runtimeClasspath += output + compileClasspath
     }
@@ -188,7 +187,6 @@ dependencies {
     integrationTestRuntimeOnly "io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion"
     integrationTestRuntimeOnly "io.confluent:kafka-json-serializer:$confluentPlatformVersion"
     integrationTestRuntimeOnly "org.junit.jupiter:junit-jupiter:$jupiterVersion"
-    integrationTestRuntimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 
     integrationTestImplementation "org.apache.kafka:connect-runtime:$kafkaVersion"
     integrationTestImplementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -122,14 +122,16 @@ ext {
     jupiterVersion = "5.9.1"
     jettyVersion = "9.4.51.v20230217"
     junit4Version = "4.13.2"
-    jsr305Version = "3.0.2"
-    log4jVersion = "2.20.0"
-    mockitoVersion = '5.1.1'
     servletVersion = "4.0.1"
-    spotbugsAnnotationsVersion = "4.5.2"
     testcontainersVersion = '1.17.6'
-    assertjVersion = "3.22.0"
     awaitilityVersion = '4.2.0'
+    jupiterVersion = "5.9.1"
+    log4jVersion = "2.20.0"
+
+    // Integration tests are not necessary to change these
+    slf4jVersion = "1.7.36"
+    derbyVersion = "10.15.2.0"
+    mockitoVersion = '5.1.1'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -216,7 +216,8 @@ task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
 
-    dependsOn test, distTar
+    // Integration tests run independently from unit tests
+    dependsOn testClasses, distTar
 
     useJUnitPlatform()
 


### PR DESCRIPTION
As [raised in #214](https://github.com/aiven/jdbc-connector-for-apache-kafka/pull/214#issuecomment-1457060161), the integration tests for this project no longer run correctly. This PR originally fixed those integration tests, but now depends on https://github.com/aiven/jdbc-connector-for-apache-kafka/pull/224 for that bit.

This PR:
- Tweaks the build file to allow integration tests to be run without also running unit tests
- Tweaks the build file to enable logging for integration tests

The first change can be verified locally by running `./gradlew clean build integrationTest`. I only see effects from the second change while running in IntelliJ; this still seems valuable, but if not, I can revert.