### PR TITLE
Enable use of unqualified table names in source connector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,7 +214,6 @@ task integrationTest(type: Test) {
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
 
-    // Integration tests run independently from unit tests
     dependsOn testClasses, distTar
 
     useJUnitPlatform()

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -22,13 +22,13 @@
     <!-- Legacy suppressions -->
     <!-- TODO: must be fixed -->
     <suppress checks="CyclomaticComplexity"
-              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread).java"/>
+              files="(BufferedRecords|DataConverter|DatabaseDialect|FieldsMetadata|HanaDialect|JdbcSourceTask|JdbcSourceConnector|MySqlDatabaseDialect|OracleDatabaseDialect|PostgreSqlDatabaseDialect|PreparedStatementBinder|SqlServerDatabaseDialect|SqliteDatabaseDialect|TimestampIncrementingTableQuerier|VerticaDatabaseDialect|SapHanaDatabaseDialect|TableId|ColumnDefinition|TableMonitorThread).java"/>
 
     <suppress checks="ClassDataAbstractionCoupling"
               files="(DbDialect|JdbcSourceTask|GenericDatabaseDialect).java"/>
 
     <suppress checks="NPathComplexity"
-              files="(DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect).java"/>
+              files="(DataConverter|FieldsMetadata|JdbcSourceTask|JdbcSourceConnector|GenericDatabaseDialect).java"/>
 
     <suppress checks="JavaNCSS"
               files="(DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect).java"/>

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/ConnectRunner.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/ConnectRunner.java
@@ -31,6 +31,7 @@ import org.apache.kafka.connect.runtime.rest.entities.ConnectorInfo;
 import org.apache.kafka.connect.runtime.standalone.StandaloneConfig;
 import org.apache.kafka.connect.runtime.standalone.StandaloneHerder;
 import org.apache.kafka.connect.storage.MemoryOffsetBackingStore;
+import org.apache.kafka.connect.util.ConnectorTaskId;
 import org.apache.kafka.connect.util.FutureCallback;
 
 import org.slf4j.Logger;
@@ -100,6 +101,22 @@ public final class ConnectRunner {
 
         final Herder.Created<ConnectorInfo> connectorInfoCreated = cb.get();
         assert connectorInfoCreated.created();
+    }
+
+    public void restartTask(final String connector, final int task) throws ExecutionException, InterruptedException {
+        assert herder != null;
+
+        final FutureCallback<Void> cb = new FutureCallback<>(
+            (error, ignored) -> {
+                if (error != null) {
+                    LOGGER.error("Failed to restart task {}-{}", connector, task, error);
+                } else {
+                    LOGGER.info("Restarted task {}-{}", connector, task);
+                }
+            });
+
+        herder.restartTask(new ConnectorTaskId(connector, task), cb);
+        cb.get();
     }
 
     void stop() {

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/AbstractPostgresIT.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/AbstractPostgresIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.jdbc.postgres;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.aiven.kafka.connect.jdbc.AbstractIT;
+
+import org.assertj.core.util.Arrays;
+import org.postgresql.ds.PGSimpleDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
+
+public class AbstractPostgresIT extends AbstractIT {
+
+    public static final String DEFAULT_POSTGRES_TAG = "10.20";
+    private static final DockerImageName DEFAULT_POSTGRES_IMAGE_NAME =
+            DockerImageName.parse("postgres")
+                    .withTag(DEFAULT_POSTGRES_TAG);
+
+    @Container
+    protected final PostgreSQLContainer<?> postgreSqlContainer = new PostgreSQLContainer<>(DEFAULT_POSTGRES_IMAGE_NAME);
+
+    protected void executeUpdate(final String updateStatement) throws SQLException {
+        try (final Connection connection = getDatasource().getConnection();
+             final Statement statement = connection.createStatement()) {
+            statement.executeUpdate(updateStatement);
+        }
+    }
+
+    protected DataSource getDatasource() {
+        final PGSimpleDataSource pgSimpleDataSource = new PGSimpleDataSource();
+        pgSimpleDataSource.setServerNames(Arrays.array(postgreSqlContainer.getHost()));
+        pgSimpleDataSource.setPortNumbers(new int[] {postgreSqlContainer.getMappedPort(5432)});
+        pgSimpleDataSource.setDatabaseName(postgreSqlContainer.getDatabaseName());
+        pgSimpleDataSource.setUser(postgreSqlContainer.getUsername());
+        pgSimpleDataSource.setPassword(postgreSqlContainer.getPassword());
+        return pgSimpleDataSource;
+    }
+
+    protected Map<String, String> basicConnectorConfig() {
+        final HashMap<String, String> config = new HashMap<>();
+        config.put("key.converter", "io.confluent.connect.avro.AvroConverter");
+        config.put("key.converter.schema.registry.url", schemaRegistryContainer.getSchemaRegistryUrl());
+        config.put("value.converter", "io.confluent.connect.avro.AvroConverter");
+        config.put("value.converter.schema.registry.url", schemaRegistryContainer.getSchemaRegistryUrl());
+        config.put("tasks.max", "1");
+        config.put("connection.url", postgreSqlContainer.getJdbcUrl());
+        config.put("connection.user", postgreSqlContainer.getUsername());
+        config.put("connection.password", postgreSqlContainer.getPassword());
+        config.put("dialect.name", "PostgreSqlDatabaseDialect");
+        return config;
+    }
+
+}

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/UnqualifiedTableNamesIntegrationTest.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/UnqualifiedTableNamesIntegrationTest.java
@@ -182,7 +182,7 @@ public class UnqualifiedTableNamesIntegrationTest extends AbstractPostgresIT {
         final Map<String, String> config = super.basicConnectorConfig();
         config.put("name", CONNECTOR_NAME);
         config.put("topic.prefix", "");
-        config.put("qualify.table.names", "false");
+        config.put("table.names.qualify", "false");
         config.put("poll.interval.ms", "1000"); // Poll quickly for shorter tests
         config.put("whitelist", TABLE);
         config.put("connector.class", JdbcSourceConnector.class.getName());

--- a/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/UnqualifiedTableNamesIntegrationTest.java
+++ b/src/integrationTest/java/io/aiven/kafka/connect/jdbc/postgres/UnqualifiedTableNamesIntegrationTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2022 Aiven Oy and jdbc-connector-for-apache-kafka project contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.jdbc.postgres;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+
+import io.aiven.connect.jdbc.JdbcSourceConnector;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UnqualifiedTableNamesIntegrationTest extends AbstractPostgresIT {
+    private static final String CONNECTOR_NAME = "test-source-connector";
+
+    private static final String TABLE = "dup";
+    private static final String PREFERRED_SCHEMA = "preferred";
+    private static final String OTHER_SCHEMA = "other";
+
+    private static final String CREATE_PREFERRED_TABLE =
+            "create table " + PREFERRED_SCHEMA + "." + TABLE + "\n"
+                    + "(\n"
+                    + "    id int          generated always as identity primary key,\n"
+                    + "    name  text      not null,\n"
+                    + "    value text      not null,\n"
+                    + "    date  timestamp not null default current_timestamp\n"
+                    + ")";
+    private static final String POPULATE_PREFERRED_TABLE =
+            "insert into " + PREFERRED_SCHEMA + "." + TABLE + " (name, value) values\n"
+                    + "('clef', 'bass')";
+    private static final String CREATE_OTHER_TABLE =
+            "create table " + OTHER_SCHEMA + "." + TABLE + "\n"
+                    + "(\n"
+                    + "    name  text      not null"
+                    + ")";
+    private static final String POPULATE_OTHER_TABLE =
+            "insert into " + OTHER_SCHEMA + "." + TABLE + " (name) values\n"
+                    + "('Rapu')"; // 🦀
+
+    @Test
+    public void testSingleTable() throws Exception {
+        createTopic(TABLE, 1);
+        consumer.assign(Collections.singleton(new TopicPartition(TABLE, 0)));
+        // Make sure that the topic starts empty
+        assertEmptyPoll(Duration.ofSeconds(1));
+
+        executeUpdate(createSchema(PREFERRED_SCHEMA));
+        executeUpdate(setSearchPath(postgreSqlContainer.getDatabaseName()));
+        executeUpdate(CREATE_PREFERRED_TABLE);
+        executeUpdate(POPULATE_PREFERRED_TABLE);
+        connectRunner.createConnector(basicTimestampModeSourceConnectorConfig());
+
+        await().atMost(Duration.ofSeconds(10)).pollInterval(Duration.ofMillis(100))
+                .until(this::assertSingleNewRecordProduced);
+    }
+
+    @Test
+    public void testMultipleTablesTimestampMode() throws Exception {
+        testMultipleTables(basicTimestampModeSourceConnectorConfig());
+    }
+
+    @Test
+    public void testMultipleTablesIncrementingMode() throws Exception {
+        final Map<String, String> connectorConfig = basicSourceConnectorConfig();
+        connectorConfig.put("mode", "incrementing");
+        connectorConfig.put("incrementing.column.name", "id");
+        testMultipleTables(connectorConfig);
+    }
+
+    @Test
+    public void testMultipleTablesTimestampIncrementingMode() throws Exception {
+        final Map<String, String> connectorConfig = basicSourceConnectorConfig();
+        connectorConfig.put("mode", "timestamp+incrementing");
+        connectorConfig.put("incrementing.column.name", "id");
+        connectorConfig.put("timestamp.column.name", "date");
+        testMultipleTables(connectorConfig);
+    }
+
+    private void testMultipleTables(final Map<String, String> connectorConfig) throws Exception {
+        createTopic(TABLE, 1);
+        consumer.assign(Collections.singleton(new TopicPartition(TABLE, 0)));
+        // Make sure that the topic starts empty
+        assertEmptyPoll(Duration.ofSeconds(1));
+
+        executeUpdate(createSchema(PREFERRED_SCHEMA));
+        executeUpdate(createSchema(OTHER_SCHEMA));
+        executeUpdate(setSearchPath(postgreSqlContainer.getDatabaseName()));
+        executeUpdate(CREATE_PREFERRED_TABLE);
+        executeUpdate(POPULATE_PREFERRED_TABLE);
+        executeUpdate(CREATE_OTHER_TABLE);
+        executeUpdate(POPULATE_OTHER_TABLE);
+        connectRunner.createConnector(connectorConfig);
+
+        await().atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
+                .until(this::assertSingleNewRecordProduced);
+
+        executeUpdate(POPULATE_OTHER_TABLE);
+
+        // Make sure that, even after adding another row to the other table, the connector
+        // doesn't publish any new records
+        assertEmptyPoll(Duration.ofSeconds(5));
+
+        // Add one more row to the preferred table, and verify that the connector
+        // is able to read it
+        executeUpdate(POPULATE_PREFERRED_TABLE);
+        await().atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
+                .until(this::assertSingleNewRecordProduced);
+
+        // Restart the connector, to ensure that offsets are tracked correctly
+        connectRunner.restartTask(CONNECTOR_NAME, 0);
+
+        // Add one more row to the preferred table, and verify that the connector
+        // is able to read it
+        executeUpdate(POPULATE_PREFERRED_TABLE);
+        await().atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100))
+                .until(this::assertSingleNewRecordProduced);
+
+        // Make sure that the connector doesn't publish any more records
+        assertEmptyPoll(Duration.ofSeconds(5));
+    }
+
+    private void assertEmptyPoll(final Duration duration) {
+        final ConsumerRecords<?, ?> records = consumer.poll(duration);
+        assertEquals(ConsumerRecords.empty(), records);
+    }
+
+    private boolean assertSingleNewRecordProduced() {
+        final ConsumerRecords<String, GenericRecord> records = consumer.poll(Duration.ofSeconds(1));
+        if (records.isEmpty()) {
+            return false;
+        }
+        assertEquals(1, records.count(), "Connector should only have produced one new record to Kafka");
+        for (final ConsumerRecord<String, GenericRecord> record : records) {
+            final Schema valueSchema = record.value().getSchema();
+            final Set<String> actualFieldNames = valueSchema.getFields().stream()
+                    .map(Schema.Field::name)
+                    .collect(Collectors.toSet());
+            final Set<String> expectedFieldNames = Set.of("id", "name", "value", "date");
+            assertEquals(
+                    expectedFieldNames,
+                    actualFieldNames,
+                    "Records produced by the connector do not have a schema that matches "
+                            + " the schema of the table it should have read from"
+            );
+        }
+        return true;
+    }
+
+    private Map<String, String> basicTimestampModeSourceConnectorConfig() {
+        final Map<String, String> config = basicSourceConnectorConfig();
+        config.put("mode", "timestamp");
+        config.put("timestamp.column.name", "date");
+        return config;
+    }
+
+    private Map<String, String> basicSourceConnectorConfig() {
+        final Map<String, String> config = super.basicConnectorConfig();
+        config.put("name", CONNECTOR_NAME);
+        config.put("topic.prefix", "");
+        config.put("qualify.table.names", "false");
+        config.put("poll.interval.ms", "1000"); // Poll quickly for shorter tests
+        config.put("whitelist", TABLE);
+        config.put("connector.class", JdbcSourceConnector.class.getName());
+        config.put("dialect.name", "PostgreSqlDatabaseDialect");
+        return config;
+    }
+
+    private static String createSchema(final String schema) {
+        return "CREATE SCHEMA " + schema;
+    }
+
+    private static String setSearchPath(final String database) {
+        return "ALTER DATABASE " + database + " SET search_path TO "
+                + PREFERRED_SCHEMA + "," + OTHER_SCHEMA;
+    }
+
+}

--- a/src/main/java/io/aiven/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/aiven/connect/jdbc/JdbcSourceConnector.java
@@ -103,7 +103,7 @@ public class JdbcSourceConnector extends SourceConnector {
         Set<String> whitelistSet = whitelist.isEmpty() ? null : new HashSet<>(whitelist);
         final List<String> blacklist = config.getList(JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG);
         final Set<String> blacklistSet = blacklist.isEmpty() ? null : new HashSet<>(blacklist);
-        final boolean qualifyTableNames = config.getBoolean(JdbcSourceConnectorConfig.QUALIFY_TABLE_NAMES_CONFIG);
+        final boolean qualifyTableNames = config.getBoolean(JdbcSourceConnectorConfig.TABLE_NAMES_QUALIFY_CONFIG);
 
         if (whitelistSet != null && blacklistSet != null) {
             throw new ConnectException(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG + " and "

--- a/src/main/java/io/aiven/connect/jdbc/JdbcSourceConnector.java
+++ b/src/main/java/io/aiven/connect/jdbc/JdbcSourceConnector.java
@@ -103,6 +103,7 @@ public class JdbcSourceConnector extends SourceConnector {
         Set<String> whitelistSet = whitelist.isEmpty() ? null : new HashSet<>(whitelist);
         final List<String> blacklist = config.getList(JdbcSourceConnectorConfig.TABLE_BLACKLIST_CONFIG);
         final Set<String> blacklistSet = blacklist.isEmpty() ? null : new HashSet<>(blacklist);
+        final boolean qualifyTableNames = config.getBoolean(JdbcSourceConnectorConfig.QUALIFY_TABLE_NAMES_CONFIG);
 
         if (whitelistSet != null && blacklistSet != null) {
             throw new ConnectException(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG + " and "
@@ -120,13 +121,35 @@ public class JdbcSourceConnector extends SourceConnector {
             whitelistSet = Collections.emptySet();
 
         }
+        final String mode = config.getMode();
+        if (JdbcSourceConnectorConfig.MODE_INCREMENTING.equals(mode)
+                || JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING.equals(mode)
+        ) {
+            final String incrementingColumn =
+                    config.getString(JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG);
+            if (!qualifyTableNames && (incrementingColumn == null || incrementingColumn.isEmpty())) {
+                // Otherwise, we may infer the wrong incrementing key for the table
+                // TODO: This restraint is not necessary in all cases, but additional logic will be required to
+                //       distinguish when it is and is not, and without that logic, the connector will fail to query
+                //       tables by trying to read a non-existent column, which is likely to be very confusing to users.
+                //       This is still technically possible even with explicitly-specified column names, but that
+                //       can happen regardless of whether unqualified table names are used
+                throw new ConnectException(
+                        "When using unqualified table names and either " + JdbcSourceConnectorConfig.MODE_INCREMENTING
+                                + " or " + JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING + " mode, an "
+                                + "incrementing column name must be explicitly provided via the '"
+                                + JdbcSourceConnectorConfig.INCREMENTING_COLUMN_NAME_CONFIG + "' property."
+                );
+            }
+        }
         tableMonitorThread = new TableMonitorThread(
             dialect,
             cachedConnectionProvider,
             context,
             tablePollMs,
             whitelistSet,
-            blacklistSet
+            blacklistSet,
+            qualifyTableNames
         );
         tableMonitorThread.start();
     }

--- a/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -263,15 +263,15 @@ public class JdbcSourceConnectorConfig extends JdbcConfig {
     private static final String TABLE_TYPE_DISPLAY = "Table Types";
 
 
-    public static final String QUALIFY_TABLE_NAMES_CONFIG = "qualify.table.names";
-    private static final String QUALIFY_TABLE_NAMES_DOC =
+    public static final String TABLE_NAMES_QUALIFY_CONFIG = "table.names.qualify";
+    private static final String TABLE_NAMES_QUALIFY_DOC =
             "Whether to use fully-qualified table names when querying the database. If disabled, "
                     + "queries will be performed with unqualified table names. This may be useful if the "
                     + "database has been configured with a search path to automatically direct unqualified "
                     + "queries to the correct table when there are multiple tables available with the same "
                     + "unqualified name";
-    public static final boolean QUALIFY_TABLE_NAMES_DEFAULT = true;
-    private static final String QUALIFY_TABLE_NAMES_DISPLAY = "Qualify table names";
+    public static final boolean TABLE_NAMES_QUALIFY_DEFAULT = true;
+    private static final String TABLE_NAMES_QUALIFY_DISPLAY = "Qualify table names";
 
     public static ConfigDef baseConfigDef() {
         final ConfigDef config = new ConfigDef();
@@ -373,15 +373,15 @@ public class JdbcSourceConnectorConfig extends JdbcConfig {
             NUMERIC_MAPPING_DISPLAY,
             NUMERIC_MAPPING_RECOMMENDER
         ).define(
-            QUALIFY_TABLE_NAMES_CONFIG,
+                TABLE_NAMES_QUALIFY_CONFIG,
             Type.BOOLEAN,
-            QUALIFY_TABLE_NAMES_DEFAULT,
+                TABLE_NAMES_QUALIFY_DEFAULT,
             Importance.LOW,
-            QUALIFY_TABLE_NAMES_DOC,
+                TABLE_NAMES_QUALIFY_DOC,
             DATABASE_GROUP,
             ++orderInGroup,
             Width.SHORT,
-            QUALIFY_TABLE_NAMES_DISPLAY
+                TABLE_NAMES_QUALIFY_DISPLAY
         );
 
         defineDbTimezone(config, ++orderInGroup);

--- a/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -262,6 +262,17 @@ public class JdbcSourceConnectorConfig extends JdbcConfig {
             + "In most cases it only makes sense to have either TABLE or VIEW.";
     private static final String TABLE_TYPE_DISPLAY = "Table Types";
 
+
+    public static final String QUALIFY_TABLE_NAMES_CONFIG = "qualify.table.names";
+    private static final String QUALIFY_TABLE_NAMES_DOC =
+            "Whether to use fully-qualified table names when querying the database. If disabled, "
+                    + "queries will be performed with unqualified table names. This may be useful if the "
+                    + "database has been configured with a search path to automatically direct unqualified "
+                    + "queries to the correct table when there are multiple tables available with the same "
+                    + "unqualified name";
+    public static final boolean QUALIFY_TABLE_NAMES_DEFAULT = true;
+    private static final String QUALIFY_TABLE_NAMES_DISPLAY = "Qualify table names";
+
     public static ConfigDef baseConfigDef() {
         final ConfigDef config = new ConfigDef();
         addDatabaseOptions(config);
@@ -361,6 +372,16 @@ public class JdbcSourceConnectorConfig extends JdbcConfig {
             Width.SHORT,
             NUMERIC_MAPPING_DISPLAY,
             NUMERIC_MAPPING_RECOMMENDER
+        ).define(
+            QUALIFY_TABLE_NAMES_CONFIG,
+            Type.BOOLEAN,
+            QUALIFY_TABLE_NAMES_DEFAULT,
+            Importance.LOW,
+            QUALIFY_TABLE_NAMES_DOC,
+            DATABASE_GROUP,
+            ++orderInGroup,
+            Width.SHORT,
+            QUALIFY_TABLE_NAMES_DISPLAY
         );
 
         defineDbTimezone(config, ++orderInGroup);

--- a/src/main/java/io/aiven/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/TableMonitorThread.java
@@ -20,6 +20,7 @@ package io.aiven.connect.jdbc.source;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +38,8 @@ import io.aiven.connect.jdbc.util.TableId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.aiven.connect.jdbc.source.JdbcSourceConnectorConfig.QUALIFY_TABLE_NAMES_CONFIG;
+
 /**
  * Thread that monitors the database for changes to the set of tables in the database that this
  * connector should load data from.
@@ -49,8 +52,9 @@ public class TableMonitorThread extends Thread {
     private final ConnectorContext context;
     private final CountDownLatch shutdownLatch;
     private final long pollMs;
-    private Set<String> whitelist;
-    private Set<String> blacklist;
+    private final Set<String> whitelist;
+    private final Set<String> blacklist;
+    private final boolean qualifyTableNames;
     private List<TableId> tables;
     private Map<String, List<TableId>> duplicates;
 
@@ -59,7 +63,8 @@ public class TableMonitorThread extends Thread {
                               final ConnectorContext context,
                               final long pollMs,
                               final Set<String> whitelist,
-                              final Set<String> blacklist
+                              final Set<String> blacklist,
+                              final boolean qualifyTableNames
     ) {
         this.dialect = dialect;
         this.connectionProvider = connectionProvider;
@@ -68,8 +73,8 @@ public class TableMonitorThread extends Thread {
         this.pollMs = pollMs;
         this.whitelist = whitelist;
         this.blacklist = blacklist;
+        this.qualifyTableNames = qualifyTableNames;
         this.tables = null;
-
     }
 
     @Override
@@ -113,7 +118,7 @@ public class TableMonitorThread extends Thread {
         if (tables == null) {
             throw new ConnectException("Tables could not be updated quickly enough.");
         }
-        if (!duplicates.isEmpty()) {
+        if (qualifyTableNames && !duplicates.isEmpty()) {
             final String configText;
             if (whitelist != null) {
                 configText = "'" + JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG + "'";
@@ -128,7 +133,8 @@ public class TableMonitorThread extends Thread {
                 + "the topic and downstream processing errors. To prevent such processing errors, the "
                 + "JDBC Source connector fails to start when it detects duplicate table name "
                 + "configurations. Update the connector's " + configText + " config to include exactly "
-                + "one table in each of the tables listed below.\n\t";
+                + "one table in each of the tables listed below or, to use unqualified table names, consider "
+                + "setting " +  QUALIFY_TABLE_NAMES_CONFIG + " to 'false'.\n\t";
             throw new ConnectException(msg + duplicates.values());
         }
         return tables;
@@ -177,22 +183,35 @@ public class TableMonitorThread extends Thread {
             filteredTables.addAll(tables);
         }
 
-        if (!filteredTables.equals(this.tables)) {
+        final List<TableId> newTables;
+        if (!qualifyTableNames) {
+            newTables = filteredTables.stream()
+                    .map(TableId::unqualified)
+                    .distinct()
+                    .collect(Collectors.toList());
+        } else {
+            newTables = filteredTables;
+        }
+
+        if (!newTables.equals(this.tables)) {
             log.info(
                 "After filtering the tables are: {}",
                 dialect.expressionBuilder()
                     .appendList()
                     .delimitedBy(",")
-                    .of(filteredTables)
+                    .of(newTables)
             );
-            final Map<String, List<TableId>> duplicates = filteredTables.stream()
-                .collect(Collectors.groupingBy(TableId::tableName))
-                .entrySet().stream()
-                .filter(entry -> entry.getValue().size() > 1)
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-            this.duplicates = duplicates;
+            if (qualifyTableNames) {
+                this.duplicates = newTables.stream()
+                    .collect(Collectors.groupingBy(TableId::tableName))
+                    .entrySet().stream()
+                    .filter(entry -> entry.getValue().size() > 1)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            } else {
+                this.duplicates = Collections.emptyMap();
+            }
             final List<TableId> previousTables = this.tables;
-            this.tables = filteredTables;
+            this.tables = newTables;
             notifyAll();
             // Only return true if the table list wasn't previously null, i.e. if this was not the
             // first table lookup

--- a/src/main/java/io/aiven/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/aiven/connect/jdbc/source/TableMonitorThread.java
@@ -38,7 +38,7 @@ import io.aiven.connect.jdbc.util.TableId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static io.aiven.connect.jdbc.source.JdbcSourceConnectorConfig.QUALIFY_TABLE_NAMES_CONFIG;
+import static io.aiven.connect.jdbc.source.JdbcSourceConnectorConfig.TABLE_NAMES_QUALIFY_CONFIG;
 
 /**
  * Thread that monitors the database for changes to the set of tables in the database that this
@@ -134,7 +134,7 @@ public class TableMonitorThread extends Thread {
                 + "JDBC Source connector fails to start when it detects duplicate table name "
                 + "configurations. Update the connector's " + configText + " config to include exactly "
                 + "one table in each of the tables listed below or, to use unqualified table names, consider "
-                + "setting " +  QUALIFY_TABLE_NAMES_CONFIG + " to 'false'.\n\t";
+                + "setting " + TABLE_NAMES_QUALIFY_CONFIG + " to 'false'.\n\t";
             throw new ConnectException(msg + duplicates.values());
         }
         return tables;

--- a/src/main/java/io/aiven/connect/jdbc/util/TableId.java
+++ b/src/main/java/io/aiven/connect/jdbc/util/TableId.java
@@ -49,6 +49,10 @@ public class TableId implements Comparable<TableId>, ExpressionBuilder.Expressab
         return tableName;
     }
 
+    public TableId unqualified() {
+        return new TableId(null, null, this.tableName);
+    }
+
     @Override
     public void appendTo(final ExpressionBuilder builder, final boolean useQuotes) {
         if (catalogName != null) {

--- a/src/test/java/io/aiven/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/JdbcSourceConnectorTest.java
@@ -174,7 +174,7 @@ public class JdbcSourceConnectorTest {
 
     @Test
     public void testPartitioningUnqualifiedTables() throws Exception {
-        connProps.put(JdbcSourceConnectorConfig.QUALIFY_TABLE_NAMES_CONFIG, "false");
+        connProps.put(JdbcSourceConnectorConfig.TABLE_NAMES_QUALIFY_CONFIG, "false");
         // Tests distributing tables across multiple tasks, in this case unevenly
         db.createTable("test1", "id", "INT NOT NULL");
         db.createTable("test2", "id", "INT NOT NULL");
@@ -222,7 +222,7 @@ public class JdbcSourceConnectorTest {
 
         connector = new JdbcSourceConnector();
         connProps.remove(JdbcSourceConnectorConfig.QUERY_CONFIG);
-        connProps.put(JdbcSourceConnectorConfig.QUALIFY_TABLE_NAMES_CONFIG, "false");
+        connProps.put(JdbcSourceConnectorConfig.TABLE_NAMES_QUALIFY_CONFIG, "false");
         connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_INCREMENTING);
         assertThrows(ConnectException.class, () -> connector.start(connProps));
 

--- a/src/test/java/io/aiven/connect/jdbc/JdbcSourceConnectorTest.java
+++ b/src/test/java/io/aiven/connect/jdbc/JdbcSourceConnectorTest.java
@@ -50,6 +50,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({JdbcSourceConnector.class, DatabaseDialect.class})
@@ -172,6 +173,29 @@ public class JdbcSourceConnectorTest {
     }
 
     @Test
+    public void testPartitioningUnqualifiedTables() throws Exception {
+        connProps.put(JdbcSourceConnectorConfig.QUALIFY_TABLE_NAMES_CONFIG, "false");
+        // Tests distributing tables across multiple tasks, in this case unevenly
+        db.createTable("test1", "id", "INT NOT NULL");
+        db.createTable("test2", "id", "INT NOT NULL");
+        db.createTable("test3", "id", "INT NOT NULL");
+        db.createTable("test4", "id", "INT NOT NULL");
+        connector.start(connProps);
+        final List<Map<String, String>> configs = connector.taskConfigs(3);
+        assertEquals(3, configs.size());
+        assertTaskConfigsHaveParentConfigs(configs);
+
+        assertEquals(unqualifiedTables("test1", "test2"), configs.get(0).get(JdbcSourceTaskConfig.TABLES_CONFIG));
+        assertNull(configs.get(0).get(JdbcSourceTaskConfig.QUERY_CONFIG));
+        assertEquals(unqualifiedTables("test3"), configs.get(1).get(JdbcSourceTaskConfig.TABLES_CONFIG));
+        assertNull(configs.get(1).get(JdbcSourceTaskConfig.QUERY_CONFIG));
+        assertEquals(unqualifiedTables("test4"), configs.get(2).get(JdbcSourceTaskConfig.TABLES_CONFIG));
+        assertNull(configs.get(2).get(JdbcSourceTaskConfig.QUERY_CONFIG));
+
+        connector.stop();
+    }
+
+    @Test
     public void testPartitioningQuery() throws Exception {
         // Tests "partitioning" when config specifies running a custom query
         db.createTable("test1", "id", "INT NOT NULL");
@@ -189,12 +213,22 @@ public class JdbcSourceConnectorTest {
         connector.stop();
     }
 
-    @Test(expected = ConnectException.class)
+    @Test
     public void testConflictingQueryTableSettings() {
         final String sampleQuery = "SELECT foo, bar FROM sample_table";
         connProps.put(JdbcSourceConnectorConfig.QUERY_CONFIG, sampleQuery);
         connProps.put(JdbcSourceConnectorConfig.TABLE_WHITELIST_CONFIG, "foo,bar");
-        connector.start(connProps);
+        assertThrows(ConnectException.class, () -> connector.start(connProps));
+
+        connector = new JdbcSourceConnector();
+        connProps.remove(JdbcSourceConnectorConfig.QUERY_CONFIG);
+        connProps.put(JdbcSourceConnectorConfig.QUALIFY_TABLE_NAMES_CONFIG, "false");
+        connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_INCREMENTING);
+        assertThrows(ConnectException.class, () -> connector.start(connProps));
+
+        connector = new JdbcSourceConnector();
+        connProps.put(JdbcSourceConnectorConfig.MODE_CONFIG, JdbcSourceConnectorConfig.MODE_TIMESTAMP_INCREMENTING);
+        assertThrows(ConnectException.class, () -> connector.start(connProps));
     }
 
     private void assertTaskConfigsHaveParentConfigs(final List<Map<String, String>> configs) {
@@ -205,9 +239,18 @@ public class JdbcSourceConnectorTest {
     }
 
     private String tables(final String... names) {
+        return tables(true, names);
+    }
+
+    private String unqualifiedTables(final String... names) {
+        return tables(false, names);
+    }
+
+    private String tables(final boolean qualified, final String... names) {
+        final String schema = qualified ? "APP" : null;
         final List<TableId> tableIds = new ArrayList<>();
         for (final String name : names) {
-            tableIds.add(new TableId(null, "APP", name));
+            tableIds.add(new TableId(null, schema, name));
         }
         final ExpressionBuilder builder = ExpressionBuilder.create();
         builder.appendList().delimitedBy(",").of(tableIds);


### PR DESCRIPTION
Implements https://github.com/aiven/jdbc-connector-for-apache-kafka/issues/219

Depends on https://github.com/aiven/jdbc-connector-for-apache-kafka/pull/222

A new `table.names.qualify` property is introduced, with a default of `true` (which preserves existing behavior). When set to `false`:

- The connector no longer fails if it detects multiple tables with the same unqualified name
- Queries are run against the database using unqualified table names
- If running in incremental or incremental+timestamp mode, an incremental column must be explicitly specified in the connector config (automatic deduction of incremental columns is not supported)

Existing unit tests are adapted/expanded to cover fine-grained logic for this feature, and a new `UnqualifiedTableNamesIntegrationTest` integration test suite is added to test a few scenarios including different query modes and preservation of offsets across restarts.